### PR TITLE
Additional parameters for validate numericality

### DIFF
--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -8,15 +8,55 @@ module Shoulda # :nodoc:
       # * <tt>with_message</tt> - value the test expects to find in
       #   <tt>errors.on(:attribute)</tt>. Regexp or string.  Defaults to the
       #   translation for <tt>:not_a_number</tt>.
+      # * <tt>with_greater_than_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'greater_than' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:greater_than</tt>.
+      # * <tt>with_less_than_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'less_than' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:less_than</tt>.
+      # * <tt>with_greater_than_or_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'greater_than_or_equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:greater_than_or_equal_to</tt>.
+      # * <tt>with_less_than_or_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'less_than_or_equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:less_than_or_equal_to</tt>.
+      # * <tt>with_equal_to_message</tt> - value the test expects to find in
+      #   <tt>errors.on(:attribute)</tt> when parameter 'equal_to' added. Regexp or string.  Defaults to the
+      #   translation for <tt>:equal_to</tt>.
       #
       # Example:
       #   it { should validate_numericality_of(:age) }
+      #   it { should validate_numericality_of(:age).with_message('custom message') }
+      #   it { should validate_numericality_of(:age).greater_than(18) }
+      #   it { should validate_numericality_of(:age).greater_than(18).with_greater_than_message('custom message') }
+      #   it { should validate_numericality_of(:age).less_than(300) }
+      #   it { should validate_numericality_of(:age).less_than(300).with_less_than_message('custom message') }
+      #   it { should validate_numericality_of(:age).greater_than_or_equal_to(18) }
+      #   it { should validate_numericality_of(:age).greater_than_or_equal_to(18).with_greater_than_or_equal_to_message('custom message') }
+      #   it { should validate_numericality_of(:age).less_than_or_equal_to(300) }
+      #   it { should validate_numericality_of(:age).less_than_or_equal_to(300).with_less_than_or_equal_to_message('custom message') }
+      #   it { should validate_numericality_of(:age).equal_to(25) }
+      #   it { should validate_numericality_of(:age).equal_to(25).with_equal_to_message('custom message') }
       #
       def validate_numericality_of(attr)
         ValidateNumericalityOfMatcher.new(attr)
       end
 
       class ValidateNumericalityOfMatcher < ValidationMatcher # :nodoc:
+        include Helpers
+
+        [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |method|
+          define_method(method) do |number|
+            instance_variable_set("@#{method}".to_sym, number) if number
+            instance_variable_set("@#{method}_message".to_sym, method) unless instance_variable_get("@#{method}_message")
+            self
+          end
+
+          define_method("with_#{method}_message") do |message|
+            instance_variable_set("@#{method}_message".to_sym, message) if message
+            self
+          end
+        end
 
         def with_message(message)
           @expected_message = message if message
@@ -25,15 +65,74 @@ module Shoulda # :nodoc:
 
         def matches?(subject)
           super(subject)
+
           @expected_message ||= :not_a_number
-          disallows_value_of('abcd', @expected_message)
+          translate_messages!
+
+          disallows_greater_than_value &&
+            disallows_less_than_value &&
+            disallows_greater_than_or_equal_to_value &&
+            disallows_less_than_or_equal_to_value &&
+            disallows_equal_to_value &&
+            disallows_text_value
         end
 
         def description
-          "only allow numeric values for #{@attribute}"
+          result = "only allow numeric values"
+          [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |method|
+            result << "#{method} #{instance_variable_get("@#{method}")}" if instance_variable_get("@#{method}")
+          end
+          result.join(', ') + " for #{@attribute}"
         end
-      end
 
+        private
+          def disallows_greater_than_value
+            @greater_than.nil? ? true : disallows_value_of(@greater_than, @greater_than_message)
+          end
+
+          def disallows_less_than_value
+            @less_than.nil? ? true : disallows_value_of(@less_than, @less_than_message)
+          end
+
+          def disallows_greater_than_or_equal_to_value
+            @greater_than_or_equal_to.nil? ? true : disallows_value_of(@greater_than_or_equal_to-1, @greater_than_or_equal_to_message)
+          end
+
+          def disallows_less_than_or_equal_to_value
+            @less_than_or_equal_to.nil? ? true : disallows_value_of(@less_than_or_equal_to+1, @less_than_or_equal_to_message)
+          end
+
+          def disallows_equal_to_value
+            @equal_to.nil? ? true : disallows_value_of(@equal_to+1, @equal_to_message)
+          end
+
+          def disallows_text_value
+            disallows_value_of('abcd', @expected_message)
+          end
+
+          def translate_messages!
+            if Symbol === @greater_than_message
+              @greater_than_message = default_error_message(@greater_than_message, :count => @greater_than)
+            end
+
+            if Symbol === @less_than_message
+              @less_than_message = default_error_message(@less_than_message, :count => @less_than)
+            end
+
+            if Symbol === @greater_than_or_equal_to_message
+              @greater_than_or_equal_to_message = default_error_message(@greater_than_or_equal_to_message, :count => @greater_than_or_equal_to)
+            end
+
+            if Symbol === @less_than_or_equal_to_message
+              @less_than_or_equal_to_message = default_error_message(@less_than_or_equal_to_message, :count => @less_than_or_equal_to)
+            end
+
+            if Symbol === @equal_to_message
+              @equal_to_message = default_error_message(@equal_to_message, :count => @equal_to)
+            end
+          end
+
+      end
     end
   end
 end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -46,8 +46,8 @@ module Shoulda # :nodoc:
         include Helpers
 
         def greater_than(number)
-          @greater_than = number if number
-          @greater_than_message = :greater_than unless @greater_than_message
+          @greater_than = number
+          @greater_than_message ||= :greater_than
           self
         end
 
@@ -57,8 +57,8 @@ module Shoulda # :nodoc:
         end
 
         def less_than(number)
-          @less_than = number if number
-          @less_than_message = :less_than unless @less_than_message
+          @less_than = number
+          @less_than_message ||= :less_than
           self
         end
 
@@ -68,8 +68,8 @@ module Shoulda # :nodoc:
         end
 
         def greater_than_or_equal_to(number)
-          @greater_than_or_equal_to = number if number
-          @greater_than_or_equal_to_message = :greater_than_or_equal_to unless @greater_than_or_equal_to_message
+          @greater_than_or_equal_to = number
+          @greater_than_or_equal_to_message ||= :greater_than_or_equal_to
           self
         end
 
@@ -79,8 +79,8 @@ module Shoulda # :nodoc:
         end
 
         def less_than_or_equal_to(number)
-          @less_than_or_equal_to = number if number
-          @less_than_or_equal_to_message = :less_than_or_equal_to unless @less_than_or_equal_to_message
+          @less_than_or_equal_to = number
+          @less_than_or_equal_to_message ||= :less_than_or_equal_to
           self
         end
 
@@ -90,8 +90,8 @@ module Shoulda # :nodoc:
         end
 
         def equal_to(number)
-          @equal_to = number if number
-          @equal_to_message = :equal_to unless @equal_to_message
+          @equal_to = number
+          @equal_to_message ||= :equal_to
           self
         end
 
@@ -127,52 +127,51 @@ module Shoulda # :nodoc:
         end
 
         private
-          def disallows_greater_than_value
-            @greater_than.nil? ? true : disallows_value_of(@greater_than, @greater_than_message)
+        def disallows_greater_than_value
+          @greater_than.nil? || disallows_value_of(@greater_than, @greater_than_message)
+        end
+
+        def disallows_less_than_value
+          @less_than.nil? || disallows_value_of(@less_than, @less_than_message)
+        end
+
+        def disallows_greater_than_or_equal_to_value
+          @greater_than_or_equal_to.nil? || disallows_value_of(@greater_than_or_equal_to-1, @greater_than_or_equal_to_message)
+        end
+
+        def disallows_less_than_or_equal_to_value
+          @less_than_or_equal_to.nil? || disallows_value_of(@less_than_or_equal_to+1, @less_than_or_equal_to_message)
+        end
+
+        def disallows_equal_to_value
+          @equal_to.nil? || disallows_value_of(@equal_to+1, @equal_to_message)
+        end
+
+        def disallows_text_value
+          disallows_value_of('abcd', @expected_message)
+        end
+
+        def translate_messages!
+          if Symbol === @greater_than_message
+            @greater_than_message = default_error_message(@greater_than_message, :count => @greater_than)
           end
 
-          def disallows_less_than_value
-            @less_than.nil? ? true : disallows_value_of(@less_than, @less_than_message)
+          if Symbol === @less_than_message
+            @less_than_message = default_error_message(@less_than_message, :count => @less_than)
           end
 
-          def disallows_greater_than_or_equal_to_value
-            @greater_than_or_equal_to.nil? ? true : disallows_value_of(@greater_than_or_equal_to-1, @greater_than_or_equal_to_message)
+          if Symbol === @greater_than_or_equal_to_message
+            @greater_than_or_equal_to_message = default_error_message(@greater_than_or_equal_to_message, :count => @greater_than_or_equal_to)
           end
 
-          def disallows_less_than_or_equal_to_value
-            @less_than_or_equal_to.nil? ? true : disallows_value_of(@less_than_or_equal_to+1, @less_than_or_equal_to_message)
+          if Symbol === @less_than_or_equal_to_message
+            @less_than_or_equal_to_message = default_error_message(@less_than_or_equal_to_message, :count => @less_than_or_equal_to)
           end
 
-          def disallows_equal_to_value
-            @equal_to.nil? ? true : disallows_value_of(@equal_to+1, @equal_to_message)
+          if Symbol === @equal_to_message
+            @equal_to_message = default_error_message(@equal_to_message, :count => @equal_to)
           end
-
-          def disallows_text_value
-            disallows_value_of('abcd', @expected_message)
-          end
-
-          def translate_messages!
-            if Symbol === @greater_than_message
-              @greater_than_message = default_error_message(@greater_than_message, :count => @greater_than)
-            end
-
-            if Symbol === @less_than_message
-              @less_than_message = default_error_message(@less_than_message, :count => @less_than)
-            end
-
-            if Symbol === @greater_than_or_equal_to_message
-              @greater_than_or_equal_to_message = default_error_message(@greater_than_or_equal_to_message, :count => @greater_than_or_equal_to)
-            end
-
-            if Symbol === @less_than_or_equal_to_message
-              @less_than_or_equal_to_message = default_error_message(@less_than_or_equal_to_message, :count => @less_than_or_equal_to)
-            end
-
-            if Symbol === @equal_to_message
-              @equal_to_message = default_error_message(@equal_to_message, :count => @equal_to)
-            end
-          end
-
+        end
       end
     end
   end

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -45,17 +45,59 @@ module Shoulda # :nodoc:
       class ValidateNumericalityOfMatcher < ValidationMatcher # :nodoc:
         include Helpers
 
-        [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |method|
-          define_method(method) do |number|
-            instance_variable_set("@#{method}".to_sym, number) if number
-            instance_variable_set("@#{method}_message".to_sym, method) unless instance_variable_get("@#{method}_message")
-            self
-          end
+        def greater_than(number)
+          @greater_than = number if number
+          @greater_than_message = :greater_than unless @greater_than_message
+          self
+        end
 
-          define_method("with_#{method}_message") do |message|
-            instance_variable_set("@#{method}_message".to_sym, message) if message
-            self
-          end
+        def with_greater_than_message(message)
+          @greater_than_message = message if message
+          self
+        end
+
+        def less_than(number)
+          @less_than = number if number
+          @less_than_message = :less_than unless @less_than_message
+          self
+        end
+
+        def with_less_than_message(message)
+          @less_than_message = message if message
+          self
+        end
+
+        def greater_than_or_equal_to(number)
+          @greater_than_or_equal_to = number if number
+          @greater_than_or_equal_to_message = :greater_than_or_equal_to unless @greater_than_or_equal_to_message
+          self
+        end
+
+        def with_greater_than_or_equal_to_message(message)
+          @greater_than_or_equal_to_message = message if message
+          self
+        end
+
+        def less_than_or_equal_to(number)
+          @less_than_or_equal_to = number if number
+          @less_than_or_equal_to_message = :less_than_or_equal_to unless @less_than_or_equal_to_message
+          self
+        end
+
+        def with_less_than_or_equal_to_message(message)
+          @less_than_or_equal_to_message = message if message
+          self
+        end
+
+        def equal_to(number)
+          @equal_to = number if number
+          @equal_to_message = :equal_to unless @equal_to_message
+          self
+        end
+
+        def with_equal_to_message(message)
+          @equal_to_message = message if message
+          self
         end
 
         def with_message(message)

--- a/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
+++ b/lib/shoulda/matchers/active_model/validate_numericality_of_matcher.rb
@@ -78,11 +78,10 @@ module Shoulda # :nodoc:
         end
 
         def description
-          result = "only allow numeric values"
-          [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |method|
-            result << "#{method} #{instance_variable_get("@#{method}")}" if instance_variable_get("@#{method}")
+          result = [:greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to, :equal_to].map do |method|
+            "#{method} #{instance_variable_get("@#{method}")}" if instance_variable_get("@#{method}")
           end
-          result.join(', ') + " for #{@attribute}"
+          ["allow numeric values", result.compact.join(', '), "for", @attribute].join(" ")
         end
 
         private

--- a/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
@@ -36,6 +36,48 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |parameter|
+    context "a numeric attribute with a '#{parameter.to_s}' parameter" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr, parameter => 0
+        end
+        @model = Example.new
+      end
+
+      it "should only allow numeric values #{parameter} indicated value for that attribute" do
+        @model.should validate_numericality_of(:attr).send(parameter, 0)
+      end
+    end
+
+    context "a numeric attribute without a '#{parameter.to_s}' parameter" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr
+        end
+        @model = Example.new
+      end
+
+      it "should not allow numeric values without #{parameter} indicated value for that attribute" do
+        @model.should_not validate_numericality_of(:attr).send(parameter, 0)
+      end
+    end
+
+    context "a numeric attribute with a '#{parameter.to_s}' parameter and a custom message" do
+      before do
+        define_model(:example, :attr => :integer) do
+          validates_numericality_of :attr
+          validates_numericality_of :attr, parameter => 0, :message => "#{parameter} custom message"
+        end
+        @model = Example.new
+      end
+
+      it "should only allow numeric values #{parameter} indicated value for that attribute with message '#{parameter} custom message'" do
+        @model.should validate_numericality_of(:attr).send(parameter, 0).send("with_#{parameter}_message", "#{parameter} custom message")
+      end
+    end
+  end
+
   context "a non-numeric attribute" do
     before do
       @model = define_model(:example, :attr => :string).new

--- a/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
@@ -78,6 +78,20 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
+  context "description tests" do
+    [:greater_than, :greater_than_or_equal_to, :equal_to, :less_than, :less_than_or_equal_to].each do |parameter|
+      it "should return the correct description when the #{parameter} validation fails" do
+        validate_numericality_of(:attr).send(parameter, 0).description.should == "allow numeric values #{parameter} 0 for attr"
+      end
+    end
+
+    [:greater_than, :greater_than_or_equal_to].product([:less_than_or_equal_to, :less_than]).each do |parameters|
+      it "should return the correct description when the #{parameters.join(", ")} validations fails" do
+        validate_numericality_of(:attr).send(parameters.first, 0).send(parameters.last, 10).description.should == "allow numeric values #{parameters.first} 0, #{parameters.last} 10 for attr"
+      end
+    end
+  end
+
   context "a non-numeric attribute" do
     before do
       @model = define_model(:example, :attr => :string).new

--- a/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
+++ b/spec/shoulda/active_model/validate_numericality_of_matcher_spec.rb
@@ -36,7 +36,7 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
     end
   end
 
-  [:greater_than, :less_than, :greater_than_or_equal_to, :less_than_or_equal_to, :equal_to].each do |parameter|
+  all_possible_validate_numericality_of_methods.each do |parameter|
     context "a numeric attribute with a '#{parameter.to_s}' parameter" do
       before do
         define_model(:example, :attr => :integer) do
@@ -79,15 +79,15 @@ describe Shoulda::Matchers::ActiveModel::ValidateNumericalityOfMatcher do
   end
 
   context "description tests" do
-    [:greater_than, :greater_than_or_equal_to, :equal_to, :less_than, :less_than_or_equal_to].each do |parameter|
+    all_possible_validate_numericality_of_methods.each do |parameter|
       it "should return the correct description when the #{parameter} validation fails" do
         validate_numericality_of(:attr).send(parameter, 0).description.should == "allow numeric values #{parameter} 0 for attr"
       end
     end
 
-    [:greater_than, :greater_than_or_equal_to].product([:less_than_or_equal_to, :less_than]).each do |parameters|
-      it "should return the correct description when the #{parameters.join(", ")} validations fails" do
-        validate_numericality_of(:attr).send(parameters.first, 0).send(parameters.last, 10).description.should == "allow numeric values #{parameters.first} 0, #{parameters.last} 10 for attr"
+    all_possible_combinations_of_greater_than_or_less_than_methods.each do |parameter_with_greater, parameter_with_less|
+      it "should return the correct description when the #{parameter_with_greater}, #{parameter_with_less} validations fails" do
+        validate_numericality_of(:attr).send(parameter_with_greater, 0).send(parameter_with_less, 10).description.should == "allow numeric values #{parameter_with_greater} 0, #{parameter_with_less} 10 for attr"
       end
     end
   end

--- a/spec/support/validate_numericality_of.rb
+++ b/spec/support/validate_numericality_of.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |c|
+  def all_possible_combinations_of_greater_than_or_less_than_methods
+    [:greater_than, :greater_than_or_equal_to].product([:less_than_or_equal_to, :less_than])
+  end
+
+  def all_possible_validate_numericality_of_methods
+    [:greater_than, :greater_than_or_equal_to, :equal_to, :less_than, :less_than_or_equal_to]
+  end
+end
+


### PR DESCRIPTION
I merged the current master branch with pull request from:

https://github.com/thoughtbot/shoulda-matchers/pull/82

and resolved merge conflicts.

The code has changed a little bit, so it is possible that it will require some refactoring. Few suggestions:
1. use @options hash, instead instance variables. Example:

``` ruby
    def greater_than(number)
      @options[:greater_than] = number
      @options[:grader_than_message] ||= :greater_than
    end
```
1. disallows_text? and disallows_non_integers? methods have _?_ at the end of the method, but new methods like disallows_equal_to_value, doesn't have it. It would be good to make it uniform.
